### PR TITLE
Add g:terminal_fixheight option

### DIFF
--- a/plugin/terminal_help.vim
+++ b/plugin/terminal_help.vim
@@ -175,7 +175,7 @@ function! TerminalOpen()
 		if get(g:, 'terminal_list', 1) == 0
 			setlocal nobuflisted
 		endif
-		if get(g:, 'terminal_fixheight', 0) == 0
+		if get(g:, 'terminal_fixheight', 0)
 			setlocal winfixheight
 		endif
 	endif

--- a/plugin/terminal_help.vim
+++ b/plugin/terminal_help.vim
@@ -175,6 +175,9 @@ function! TerminalOpen()
 		if get(g:, 'terminal_list', 1) == 0
 			setlocal nobuflisted
 		endif
+		if get(g:, 'terminal_fixheight', 0) == 0
+			setlocal winfixheight
+		endif
 	endif
 	let x = win_getid()
 	noautocmd windo call s:terminal_view(1)


### PR DESCRIPTION
If `g:terminal_fixheight` is set to 1, `winfixheight` will be set in the terminal window.