### PR TITLE
Fix "terminal_fixheight" not taking effect after toggling

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ tell vim to open `abc.txt`
 - `g:terminal_edit`: command to open the file in vim, default to `tab drop`.
 - `g:terminal_kill`: set to `term` to kill term session when exiting vim.
 - `g:terminal_list`: set to 0 to hide terminal buffer in the buffer list.
+- `g:terminal_fixheight`: set to 1 to set `winfixheight` for the terminal window.
 
 
 ## Remember

--- a/plugin/terminal_help.vim
+++ b/plugin/terminal_help.vim
@@ -175,14 +175,14 @@ function! TerminalOpen()
 		if get(g:, 'terminal_list', 1) == 0
 			setlocal nobuflisted
 		endif
-		if get(g:, 'terminal_fixheight', 0)
-			setlocal winfixheight
-		endif
 	endif
 	let x = win_getid()
 	noautocmd windo call s:terminal_view(1)
 	noautocmd call win_gotoid(uid)    " take care of previous window
 	noautocmd call win_gotoid(x)
+	if get(g:, 'terminal_fixheight', 0)
+		setlocal winfixheight
+	endif
 endfunc
 
 


### PR DESCRIPTION
1) Fix `terminal_fixheight` not taking effect after toggling.
2) Update README for `terminal_fixheight`.