### PR TITLE
Add g:terminal_close_when_exit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ tell vim to open `abc.txt`
 - `g:terminal_kill`: set to `term` to kill term session when exiting vim.
 - `g:terminal_list`: set to 0 to hide terminal buffer in the buffer list.
 - `g:terminal_fixheight`: set to 1 to set `winfixheight` for the terminal window.
+- `g:terminal_close_when_exit`: set to 1 to destroy terminal buffer when shell closed
 
 
 ## Remember

--- a/plugin/terminal_help.vim
+++ b/plugin/terminal_help.vim
@@ -218,6 +218,28 @@ function! TerminalClose()
 	call win_gotoid(sid)
 endfunc
 
+"----------------------------------------------------------------------
+" exit terminal
+"----------------------------------------------------------------------
+
+function! TerminalQuit()
+	let bid = get(t:, '__terminal_bid__', -1)
+	if bid < 0
+		return
+	endif
+	let name = bufname(bid)
+	if name == ''
+		return
+	endif
+    exec "bw! ". name
+endfunc
+
+if exists('g:terminal_close_when_exit')
+    if g:terminal_close_when_exit == 1
+        au TermClose * call TerminalQuit()
+    endif
+endif
+
 
 "----------------------------------------------------------------------
 " toggle open/close

--- a/plugin/terminal_help.vim
+++ b/plugin/terminal_help.vim
@@ -235,8 +235,10 @@ function! TerminalQuit()
 endfunc
 
 if exists('g:terminal_close_when_exit')
-    if g:terminal_close_when_exit == 1
-        au TermClose * call TerminalQuit()
+    if has('nvim')
+        if g:terminal_close_when_exit == 1
+            au TermClose * call TerminalQuit()
+        endif
     endif
 endif
 


### PR DESCRIPTION
add optional  g:terminal_close_when_exit to close the terminal buffer when the shell in terminal is exit

for example if i run some command like `make && exit` it take time and i toggle the terminal off. once i open terminal again , I expect the terminal buffer is destory and i open a new terminal buffer.

``` vim
:TerminalOpen()<CR>
sleep 1 && exit
:TerminalClose()<CR>
" the terminal will quit 1 second later
```