### PR TITLE
Document g:terminal_skip_key_init and simplify its usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ tell vim to open `abc.txt`
 - `g:terminal_list`: set to 0 to hide terminal buffer in the buffer list.
 - `g:terminal_fixheight`: set to 1 to set `winfixheight` for the terminal window.
 - `g:terminal_close`: set to 1 to close window if process finished.
+- `g:terminal_skip_key_init`: set to 1 if you don't use the 'ALT' key and don't want this plugin to adjust options that recognises it.
 
 
 ## Remember

--- a/doc/terminal_help.txt
+++ b/doc/terminal_help.txt
@@ -108,6 +108,9 @@ Settings ~
 - 'g:terminal_fixheight': set to 1 to set 'winfixheight' for the terminal
   window.
 - 'g:terminal_close': set to 1 to close window if process finished.
+- 'g:terminal_skip_key_init': set to 1 if you don't use the 'ALT' key and
+  don't want this plugin to adjust options that recognises it.
+
 
 ===============================================================================
                                                        *terminal_help-remember*

--- a/plugin/terminal_help.vim
+++ b/plugin/terminal_help.vim
@@ -381,7 +381,9 @@ endfunc
 "----------------------------------------------------------------------
 " enable alt key in terminal vim
 "----------------------------------------------------------------------
-if has('nvim') == 0 && has('gui_running') == 0
+if has('nvim') == 0
+			\ && has('gui_running') == 0
+			\ && get(g:, 'terminal_skip_key_init', 0) == 0
 	set ttimeout
 	if $TMUX != ''
 		set ttimeoutlen=35
@@ -389,9 +391,7 @@ if has('nvim') == 0 && has('gui_running') == 0
 		set ttimeoutlen=85
 	endif
 	function! s:meta_code(key)
-		if get(g:, 'terminal_skip_key_init', 0) == 0
-			exec "set <M-".a:key.">=\e".a:key
-		endif
+		exec "set <M-".a:key.">=\e".a:key
 	endfunc
 	for i in range(10)
 		call s:meta_code(nr2char(char2nr('0') + i))
@@ -407,9 +407,7 @@ if has('nvim') == 0 && has('gui_running') == 0
 		call s:meta_code(c)
 	endfor
 	function! s:key_escape(name, code)
-		if get(g:, 'terminal_skip_key_init', 0) == 0
-			exec "set ".a:name."=\e".a:code
-		endif
+		exec "set ".a:name."=\e".a:code
 	endfunc
 	call s:key_escape('<F1>', 'OP')
 	call s:key_escape('<F2>', 'OQ')


### PR DESCRIPTION
Fix #15. Also avoids changing ttimeout and ttimeoutlen if this option is
set to 1, because I didn't see why they needed to be changed if you weren't calling the relevant options.